### PR TITLE
Hotfix for JPA DDL issue

### DIFF
--- a/GitPractice/ImageHoster/src/main/java/ImageHoster/model/Tag.java
+++ b/GitPractice/ImageHoster/src/main/java/ImageHoster/model/Tag.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Entity
 //@Table annotation provides more options to customize the mapping.
 //Here the name of the table to be created in the database is explicitly mentioned as 'Tags'. Hence the table named 'Tags' will be created in the database with all the columns mapped to all the attributes in 'Tag' class
-@Table(name = "Tags")
+@Table(name = "tags")
 public class Tag {
 
     //@Id annotation specifies that the corresponding attribute is a primary key


### PR DESCRIPTION
Updated Tag model to map to 'tags' table and not 'Tags' This resolves the alter table DDL issue when creating the FKs to  image and user models